### PR TITLE
Suppress deprecated warning  / File.exists?

### DIFF
--- a/lib/rack/revision.rb
+++ b/lib/rack/revision.rb
@@ -40,7 +40,7 @@ module Rack
     end
 
     def fetch_from_file
-      if ::File.exists?(detected_filename)
+      if ::File.exist?(detected_filename)
         ::File.read(detected_filename).strip
       end
     end


### PR DESCRIPTION
It was displayed warning logs every time it ran the test.

```
./workspaces/rack-revision/lib/rack/revision.rb:43: warning: File.exists? is deprecated; use File.exist? instead
```

`File.exists?` is deprecated since Ruby 2.1