### PR TITLE
Prevent crash on Dir.pwd call when directory no longer exists

### DIFF
--- a/lib/rack/revision.rb
+++ b/lib/rack/revision.rb
@@ -9,6 +9,7 @@ module Rack
       initialize_options(options)
 
       @app = app
+      @dir = Dir.pwd
     end
 
     def call(env)
@@ -50,7 +51,7 @@ module Rack
     end
 
     def detected_filename
-      @file ||= (@options[:filename] =~ /\A\// ? @options[:filename] : File.join(Dir.pwd, @options[:filename]))
+      @file ||= (@options[:filename] =~ /\A\// ? @options[:filename] : File.join(@dir, @options[:filename]))
     end
 
     def initialize_options(options)

--- a/test/test_revision.rb
+++ b/test/test_revision.rb
@@ -106,10 +106,13 @@ class TestRevision < Test::Unit::TestCase
     File.write("./test/tmp/REVISION", "example")
 
     Dir.chdir("./test/tmp") do
-      self.app = Rack::Revision.new(default_app)
       self.app.reset_revision
 
+      get app_url
+      assert_equal "example", last_response.headers["X-Revision"]
+
       FileUtils.rm_rf("../tmp")
+      self.app.reset_revision
 
       get app_url
       assert_equal "UNDEFINED", last_response.headers["X-Revision"]

--- a/test/test_revision.rb
+++ b/test/test_revision.rb
@@ -102,6 +102,20 @@ class TestRevision < Test::Unit::TestCase
     assert_equal "qwe123", last_response.headers["X-Revision"]
   end
 
+  def test_dir_does_not_exist
+    File.write("./test/tmp/REVISION", "example")
+
+    Dir.chdir("./test/tmp") do
+      self.app = Rack::Revision.new(default_app)
+      self.app.reset_revision
+
+      FileUtils.rm_rf("../tmp")
+
+      get app_url
+      assert_equal "UNDEFINED", last_response.headers["X-Revision"]
+    end
+  end
+
   def test_env_is_present
     self.app.reset_revision
     get app_url


### PR DESCRIPTION
Calling `Dir.pwd` in a directory that no longer exists causes an exception that affects the rack call chain.