### PR TITLE
Add Ruby 3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby


### PR DESCRIPTION
Ruby 3.2 released 🎅 
ref. https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/