### PR TITLE
Use checkout@v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         ruby: ['2.6', '2.7', '3.0', '3.1', '3.2']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}


### PR DESCRIPTION
I updated the version because the dependent Node.js is reaching EOL.
CHANGELOG: https://github.com/actions/checkout/blob/main/CHANGELOG.md

https://github.com/actions/checkout/pull/1436#issue-1863475482

> Node16 has en end of life on 11 Sep 2023.