### PR TITLE
Add Ruby 3.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
     steps:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Ruby 3.4 is out 🎅 
ref. https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/